### PR TITLE
Add repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": "https://github.com/WebCloud/ember-drag-n-drop-upload.git",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This way it'll get picked up by the NPM registry and from there to places that use NPM data (like Ember Observer)
